### PR TITLE
Import from collections.abc to remove warning

### DIFF
--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from collections import Mapping
+from collections.abc import Mapping
 
 __author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2017, Paweł Zadrożny'


### PR DESCRIPTION
I've changed the import to ` from collections.abc import Mapping` in order to get rid of this warning and make sure the library will work with Python 3.8 and above:

```
/usr/local/lib/python3.7/site-packages/dotty_dict/dotty_dict.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
from collections import Mapping

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```