### PR TITLE
Support lists inside dotty

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,6 @@ Development
 Contributors
 ************
 
-**None yet. Why not be the first?**
+* Linus Groh @linusg
 
 Read more how to contribute on :ref:`Contributing`.

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Features
 * Access to deeply nested keys with dot notation: ``dot['deeply.nested.key']``
 * Create, read, update and delete nested keys of any length
 * Expose all dictionary methods like ``.get``, ``.pop``, ``.keys`` and other
+* Access dicts in lists by index ``dot['parents.0.first_name']``
 
 
 Installation
@@ -71,6 +72,7 @@ Documentation
 TODO
 ====
 
+* support for setting value in multidimensional lists
 * key=value caching to speed up lookups and low down memory consumption
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -84,6 +84,19 @@ Below there is example response as dictionary, and then the way to check granted
    :emphasize-lines: 45
 
 
+Access dict with embedded lists
+===============================
+
+This scenario shows how to access subfield in a list.
+
+.. literalinclude:: ../example/advanced.py
+   :language: python
+   :dedent: 4
+   :start-after: list_embedded
+   :end-before: # end of list_embedded
+   :emphasize-lines: 4
+
+
 Escape character
 ================
 

--- a/dotty_dict/__init__.py
+++ b/dotty_dict/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from dotty_dict.dotty_dict import Dotty, dotty
+from dotty_dict.dotty_dict import Dotty, dotty, dotty_l
 
 __author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2017, Paweł Zadrożny'
 __email__ = 'pawel.zny@gmail.com'
 __version__ = '1.0.2'
-__all__ = ['Dotty', 'dotty']
+__all__ = ['Dotty', 'dotty', 'dotty_l']

--- a/example/advanced.py
+++ b/example/advanced.py
@@ -57,6 +57,28 @@ def api_request():
     # end of api_request
 
 
+def list_embedded():
+    from dotty_dict import dotty_l
+
+    # use dotty_l if you need support for lists
+    # WARNING!
+    # Right now you can read and delete from multidimensional lists
+    # but setting value is supported only for one dimensional list.
+
+    dot = dotty_l({
+        'annotations': [
+            {'label': 'app', 'value': 'webapi'},
+            {'label': 'role', 'value': 'admin'},
+        ]
+    })
+
+    assert dot['annotations.0.label'] == 'app'
+    assert dot['annotations.0.value'] == 'webapi'
+    assert dot['annotations.1.label'] == 'role'
+    assert dot['annotations.1.value'] == 'admin'
+    # end of list_embedded
+
+
 def escape_character():
     from dotty_dict import dotty
 

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+
+from dotty_dict import dotty_l as dotty
+
+
+class TestListInDotty(unittest.TestCase):
+    def setUp(self):
+        self.dot = dotty({
+            'field1': 'Value of F1',
+            'field2': 'Value of F2',
+            'field3': [
+                {
+                    'subfield1': 'Value of subfield1 (item 0)',
+                    'subfield2': 'Value of subfield2 (item 0)'
+                },
+                {
+                    'subfield1': 'Value of subfield1 (item 1)',
+                    'subfield2': 'Value of subfield2 (item 1)'
+                },
+            ],
+            'field4': 'Not wanted',
+            'field5': [
+                {
+                    'subfield1': [{'subsubfield': 'Value of sub subfield (item 0)'}]
+                }
+            ]
+        })
+
+    def test_access_subfield1_of_field3(self):
+        self.assertEqual(self.dot['field3.0.subfield1'], 'Value of subfield1 (item 0)')
+        self.assertEqual(self.dot['field3.1.subfield1'], 'Value of subfield1 (item 1)')
+
+    def test_access_sub_sub_field(self):
+        self.assertEqual(self.dot['field5.0.subfield1.0.subsubfield'], 'Value of sub subfield (item 0)')
+
+    def test_access_multidimensional_lists(self):
+        dot = dotty({
+            'field': [
+                [{'subfield': 'Value of subfield (item 0,0)'}],
+                [{'subfield': 'Value of subfield (item 0,1)'}]
+            ]
+        })
+        self.assertEqual(dot['field.1.0.subfield'], 'Value of subfield (item 0,1)')
+
+    def test_dotty_contains_subfield_of_field(self):
+        self.assertIn('field3.0.subfield2', self.dot)
+
+    def test_dotty_not_contains_out_of_range_subfield(self):
+        self.assertNotIn('field3.3.subfield1', self.dot)
+
+    def test_assert_key_error_if_index_is_not_integer(self):
+        with self.assertRaises(KeyError):
+            val = self.dot['field3.subfield1']  # noqa
+
+    def test_assert_index_error_if_index_is_out_of_range(self):
+        with self.assertRaises(IndexError):
+            val = self.dot['field3.4.subfield1']  # noqa
+
+    def test_set_subfield_in_list(self):
+        dot = dotty()
+
+        dot['field.0.subfield'] = 'Value of subfield (item 0)'
+        dot['field.1.subfield'] = 'Value of subfield (item 1)'
+        dot['field.1.subfield2'] = 'Value of subfield2 (item 1)'
+
+        self.assertDictEqual(dot.to_dict(), {
+            'field': [
+                {'subfield': 'Value of subfield (item 0)'},
+                {'subfield': 'Value of subfield (item 1)', 'subfield2': 'Value of subfield2 (item 1)'}
+            ],
+        })
+
+    def test_update_subfield_in_list(self):
+        dot = dotty({
+            'field': [
+                {'subfield': 'Value of subfield (item 0)'},
+                {'subfield': 'Value of subfield (item 1)', 'subfield2': 'Value of subfield2 (item 1)'}
+            ],
+        })
+
+        dot['field.0.subfield'] = 'updated value'
+
+        self.assertDictEqual(dot.to_dict(), {
+            'field': [
+                {'subfield': 'updated value'},
+                {'subfield': 'Value of subfield (item 1)', 'subfield2': 'Value of subfield2 (item 1)'}
+            ],
+        })
+
+    def test_delete_subfield(self):
+        dot = dotty({'field': [
+            {
+                'subfield1': 'Value of subfield1 (item 0)',
+                'subfield2': 'Value of subfield2 (item 0)'
+            },
+        ]})
+
+        del dot['field.0.subfield2']
+
+        self.assertDictEqual(dot.to_dict(), {'field': [
+            {'subfield1': 'Value of subfield1 (item 0)'},
+        ]})


### PR DESCRIPTION
Add support for access, update, and delete for lists inside dotty dict.
Right now it is a limitation which prevents to set new value in multidimensional list.

Examples:

```python
subfield_of_first_dict_in_list = dot['field.0.subfield']
dot['field.0.subfield'] = 'updated value'
del dot['field.0.subfield']
```

Closes: #37 