### PR TITLE
Fix "setdefault" wrapper when nested key already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv*/
 build/
 develop-eggs/
 dist/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,5 +14,6 @@ Contributors
 ************
 
 * Linus Groh @linusg
+* Andreas Motl @amotl
 
 Read more how to contribute on :ref:`Contributing`.

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -269,10 +269,11 @@ class Dotty:
         :param Any default: Default value for not existing key
         :return: Value under given key or default
         """
-        if key in self._data:
+        try:
             return self.__getitem__(key)
-        self.__setitem__(key, default)
-        return default
+        except KeyError:
+            self.__setitem__(key, default)
+            return default
 
     def to_dict(self):
         """Return wrapped dictionary.

--- a/tests/test_dotty_api.py
+++ b/tests/test_dotty_api.py
@@ -121,7 +121,7 @@ class TestDictSpecificMethods(unittest.TestCase):
             },
         })
 
-    def test_setdefault_flat(self):
+    def test_setdefault_flat_not_existing(self):
         result = self.dot.setdefault('next_flat', 'new default value')
         self.assertEqual(result, 'new default value')
         self.assertDictEqual(self.dot._data, {
@@ -138,7 +138,25 @@ class TestDictSpecificMethods(unittest.TestCase):
             },
         })
 
-    def test_setdefault_nested_key(self):
+    def test_setdefault_flat_existing(self):
+        self.dot['next_flat'] = 'original value'
+        result = self.dot.setdefault('next_flat', 'new default value')
+        self.assertEqual(result, 'original value')
+        self.assertDictEqual(self.dot._data, {
+            'flat_key': 'flat value',
+            'next_flat': 'original value',
+            'deep': {
+                'nested': 12,
+                'deeper': {
+                    'secret': 'abcd',
+                    'ridiculous': {
+                        'hell': 'is here',
+                    },
+                },
+            },
+        })
+
+    def test_setdefault_nested_key_not_existing(self):
         result = self.dot.setdefault('deep.deeper.next_key', 'new default value')
         self.assertEqual(result, 'new default value')
         self.assertDictEqual(self.dot._data, {
@@ -147,6 +165,24 @@ class TestDictSpecificMethods(unittest.TestCase):
                 'nested': 12,
                 'deeper': {
                     'next_key': 'new default value',
+                    'secret': 'abcd',
+                    'ridiculous': {
+                        'hell': 'is here',
+                    },
+                },
+            },
+        })
+
+    def test_setdefault_nested_key_existing(self):
+        self.dot['deep.deeper.next_key'] = 'original value'
+        result = self.dot.setdefault('deep.deeper.next_key', 'new default value')
+        self.assertEqual(result, 'original value')
+        self.assertDictEqual(self.dot._data, {
+            'flat_key': 'flat value',
+            'deep': {
+                'nested': 12,
+                'deeper': {
+                    'next_key': 'original value',
                     'secret': 'abcd',
                     'ridiculous': {
                         'hell': 'is here',


### PR DESCRIPTION
Dear Paweł,

thanks for conceiving and maintaining this excellent module. We have been surprised to find a bug within the `setdefault` wrapper method, but truth is sometimes stranger than fiction. The problem is that `setdefault` would not honor already existing keys when addressing a nested value with a dotted notation. In order to close this gap, we have attached the corresponding patch.

Keep up the spirit and with kind regards,
Andreas.