### PR TITLE
Add support for MicroPython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv*/
 build/
 develop-eggs/
 dist/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,5 +14,6 @@ Contributors
 ************
 
 * Linus Groh @linusg
+* Andreas Motl @amotl
 
 Read more how to contribute on :ref:`Contributing`.

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 __author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2017, Paweł Zadrożny'
@@ -55,7 +58,7 @@ class Dotty:
     """
 
     def __init__(self, dictionary, separator, esc_char, list_embedded=False):
-        if not isinstance(dictionary, Mapping):
+        if not isinstance(dictionary, (Mapping, dict)):
             raise AttributeError('Dictionary must be type of dict')
         else:
             self._data = dictionary

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -269,10 +269,11 @@ class Dotty:
         :param Any default: Default value for not existing key
         :return: Value under given key or default
         """
-        if key in self._data:
+        try:
             return self.__getitem__(key)
-        self.__setitem__(key, default)
-        return default
+        except KeyError:
+            self.__setitem__(key, default)
+            return default
 
     def to_dict(self):
         """Return wrapped dictionary.

--- a/tests/test_dotty_api.py
+++ b/tests/test_dotty_api.py
@@ -121,7 +121,7 @@ class TestDictSpecificMethods(unittest.TestCase):
             },
         })
 
-    def test_setdefault_flat(self):
+    def test_setdefault_flat_not_existing(self):
         result = self.dot.setdefault('next_flat', 'new default value')
         self.assertEqual(result, 'new default value')
         self.assertDictEqual(self.dot._data, {
@@ -138,7 +138,25 @@ class TestDictSpecificMethods(unittest.TestCase):
             },
         })
 
-    def test_setdefault_nested_key(self):
+    def test_setdefault_flat_existing(self):
+        self.dot['next_flat'] = 'original value'
+        result = self.dot.setdefault('next_flat', 'new default value')
+        self.assertEqual(result, 'original value')
+        self.assertDictEqual(self.dot._data, {
+            'flat_key': 'flat value',
+            'next_flat': 'original value',
+            'deep': {
+                'nested': 12,
+                'deeper': {
+                    'secret': 'abcd',
+                    'ridiculous': {
+                        'hell': 'is here',
+                    },
+                },
+            },
+        })
+
+    def test_setdefault_nested_key_not_existing(self):
         result = self.dot.setdefault('deep.deeper.next_key', 'new default value')
         self.assertEqual(result, 'new default value')
         self.assertDictEqual(self.dot._data, {
@@ -147,6 +165,24 @@ class TestDictSpecificMethods(unittest.TestCase):
                 'nested': 12,
                 'deeper': {
                     'next_key': 'new default value',
+                    'secret': 'abcd',
+                    'ridiculous': {
+                        'hell': 'is here',
+                    },
+                },
+            },
+        })
+
+    def test_setdefault_nested_key_existing(self):
+        self.dot['deep.deeper.next_key'] = 'original value'
+        result = self.dot.setdefault('deep.deeper.next_key', 'new default value')
+        self.assertEqual(result, 'original value')
+        self.assertDictEqual(self.dot._data, {
+            'flat_key': 'flat value',
+            'deep': {
+                'nested': 12,
+                'deeper': {
+                    'next_key': 'original value',
                     'secret': 'abcd',
                     'ridiculous': {
                         'hell': 'is here',


### PR DESCRIPTION
Dear Paweł,

we are using your module within our datalogger appliance on MicroPython. While the Python 3.x is pretty much complete, the standard library has some gaps. The attached patch takes care of that and makes the module happy to run on MicroPython.

We are humbly asking if you are willing to take this. If we could mainline it, we could save on little patches like [`dotty_dict-01.patch`](https://github.com/hiveeyes/hiveeyes-micropython-firmware/blob/0.5.1/tools/dotty_dict-01.patch).

With kind regards,
Andreas.

[1] https://github.com/hiveeyes/hiveeyes-micropython-firmware