### PR TITLE
Adds support for accessing root level elements, fixes #43

### DIFF
--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -127,7 +127,10 @@ class Dotty:
                 except ValueError:
                     raise KeyError("List index must be an integer, got {}".format(it))
                 if idx < len(data):
-                    return get_from(items, data[idx])
+                    if len(items) > 0:
+                        return get_from(items, data[idx])
+                    else:
+                        return data[idx]
                 else:
                     raise IndexError("List index out of range")
             # /end Handle embedded lists

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -25,8 +25,12 @@ class TestListInDotty(unittest.TestCase):
                 {
                     'subfield1': [{'subsubfield': 'Value of sub subfield (item 0)'}]
                 }
-            ]
+            ],
+            'field6': ['a', 'b']
         })
+
+    def test_root_level_list_element(self):
+        self.assertEqual(self.dot['field6.0'], 'a')
 
     def test_access_subfield1_of_field3(self):
         self.assertEqual(self.dot['field3.0.subfield1'], 'Value of subfield1 (item 0)')


### PR DESCRIPTION
Adds an extra check for items length, to return the root level array element