### PR TITLE
[feature] Add key=value caching

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,5 +16,6 @@ Contributors
 * Linus Groh @linusg
 * Andreas Motl @amotl
 * Aneesh Devasthale @aneeshd16
+* Szymon Piotr Krasuski @Dysproz
 
 Read more how to contribute on :ref:`Contributing`.

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Features
 * Create, read, update and delete nested keys of any length
 * Expose all dictionary methods like ``.get``, ``.pop``, ``.keys`` and other
 * Access dicts in lists by index ``dot['parents.0.first_name']``
+* key=value caching to speed up lookups and low down memory consumption
 
 
 Installation
@@ -73,7 +74,6 @@ TODO
 ====
 
 * support for setting value in multidimensional lists
-* key=value caching to speed up lookups and low down memory consumption
 
 
 Quick Example

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     from collections import Mapping
 
+from functools import lru_cache
+
 __author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2017, Paweł Zadrożny'
 
@@ -73,6 +75,9 @@ class Dotty:
     def __str__(self):
         return str(self._data)
 
+    def __hash__(self):
+        return hash(str(self))
+
     def __eq__(self, other):
         try:
             return sorted(self._data.items()) == sorted(other.items())
@@ -110,6 +115,7 @@ class Dotty:
 
         return search_in(self._split(item), self._data)
 
+    @lru_cache(maxsize=32)
     def __getitem__(self, item):
         def get_from(items, data):
             """Recursively get value from dictionary deep key.

--- a/tests/test_dotty_cache.py
+++ b/tests/test_dotty_cache.py
@@ -1,0 +1,13 @@
+import unittest
+from unittest.mock import MagicMock
+from dotty_dict import dotty
+
+
+class TestDottyCache(unittest.TestCase):
+
+    def test_getitem_cache(self):
+        dot = dotty()
+        dot._data = MagicMock()
+        for i in range(10):
+            dot.get('x.y.z')
+        self.assertEqual(dot.__getitem__.cache_info().hits, 9)

--- a/tests/test_dotty_cache.py
+++ b/tests/test_dotty_cache.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
+
 from dotty_dict import dotty
 
 
@@ -8,6 +9,6 @@ class TestDottyCache(unittest.TestCase):
     def test_getitem_cache(self):
         dot = dotty()
         dot._data = MagicMock()
-        for i in range(10):
+        for _ in range(10):
             dot.get('x.y.z')
         self.assertEqual(dot.__getitem__.cache_info().hits, 9)


### PR DESCRIPTION
This review adds caching to dotty_dict.
It utilizes lru_cache from functools.

In order to make it work I had to add __hash__ method,
but apart from that it didn't require any major changes.

I observed that with caching speed of getting key is up to 3-4
times faster.

Signed-off-by: Szymon <krasuski.szymon.piotr@gmail.com>