### PR TITLE
Fix code blocks in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,19 +116,19 @@ Install for development
 
 Install dev dependencies
 
-```console
-$ make install
-```
+.. code-block:: console
+
+    $ make install
 
 Testing
 =======
 
-```console
-$ make test
-```
+.. code-block:: console
+
+    $ make test
 
 Or full tests with TOX:
 
-```console
-$ make test-all
-```
+.. code-block:: console
+
+    $ make test-all


### PR DESCRIPTION
Markdown in a reStructuredText file doesn't render correctly.

Edit: Oops, I'm confused as well... ignore "README.md", please.