### PR TITLE
Fix bug where pop() with default value raises error

### DIFF
--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -254,6 +254,8 @@ class Dotty:
 
         def pop_from(items, data):
             it = items.pop(0)
+            if it not in data:
+                return default
             if items:
                 data = data[it]
                 return pop_from(items, data)

--- a/tests/test_dotty_basics.py
+++ b/tests/test_dotty_basics.py
@@ -46,3 +46,9 @@ class TestDottyBasics(unittest.TestCase):
         self.assertNotEqual(dot, {1, 2, 3})
         self.assertNotEqual(dot, 123)
         self.assertNotEqual(dot, 'a:1, b:2')
+
+    def test_pop_with_default_value(self):
+        dot = dotty()
+        self.assertEqual(dot.pop('does.not.exist', None), None)
+        self.assertEqual(dot.pop('does.not.exist', 55), 55)
+        self.assertEqual(dot.pop('does.not.exist', 'my_value'), 'my_value')


### PR DESCRIPTION
I applied fix for bug #48 where pop() function with default value as argument raises error when key does not exist.

Furthermore, I added unittest for this case to prevent this type of bug in the future.
