### PR TITLE
[BUG] Fix key types different than string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,3 +134,15 @@ Or full tests with TOX:
 .. code-block:: console
 
     $ make test-all
+
+Limitations
+===========
+
+In some very rare cases dotty may not work properly.
+
+* When nested dictionary has two keys of different type, but with the same value.
+  In that case dotty will return dict or list under random key with passed value.
+
+* Keys in dictionary may not contain dots. If you need to use dots, please specify dotty with custom separator.
+
+* Nested keys may not be bool type. Bool type keys are only supported when calling keys with type defined value (e.g. dot[True], dot[False]).

--- a/tests/test_dotty_value_access.py
+++ b/tests/test_dotty_value_access.py
@@ -187,3 +187,63 @@ class TestDottyValueAccess(unittest.TestCase):
                 },
             },
         })
+
+    def test_string_digit_key(self):
+        dot = dotty({'field': {
+            '1': 'one',
+            '5': 'five'
+        }})
+
+        dict_one = dot['field.1']
+        dict_five = dot['field.5']
+
+        self.assertEqual(dict_one, 'one')
+        self.assertEqual(dict_five, 'five')
+
+    def test_integer_keys(self):
+        dot = dotty({'field': {
+            1: 'one',
+            5: 'five'
+        }})
+
+        dict_one = dot['field.1']
+        dict_five = dot['field.5']
+
+        self.assertEqual(dict_one, 'one')
+        self.assertEqual(dict_five, 'five')
+
+    def test_data_gathering_with_int(self):
+        dot = dotty({
+            '2': 'string_value',
+            2: 'int_value',
+            'nested': {
+                '2': 'nested_string_value',
+                3: 'nested_int_value'
+            }
+        })
+
+        dict_string = dot['2']
+        dict_int = dot[2]
+        nested_dict_string = dot['nested.2']
+        nested_dict_int = dot['nested.3']
+
+        self.assertEqual(dict_string, 'string_value')
+        self.assertEqual(dict_int, 'int_value')
+        self.assertEqual(nested_dict_string, 'nested_string_value')
+        self.assertEqual(nested_dict_int, 'nested_int_value')
+
+    def test_non_standard_key_types(self):
+        dot = Dotty({
+            3.3: 'float',
+            True: 'bool',
+            'nested': {
+                4.4: 'nested_float'
+            }
+        }, separator=',')
+
+        dict_float = dot[3.3]
+        dict_bool = dot[True]
+        nested_dict_float = dot['nested,4.4']
+        self.assertEqual(dict_float, 'float')
+        self.assertEqual(dict_bool, 'bool')
+        self.assertEqual(nested_dict_float, 'nested_float')

--- a/tests/test_dotty_value_access.py
+++ b/tests/test_dotty_value_access.py
@@ -244,9 +244,9 @@ class TestDottyValueAccess(unittest.TestCase):
 
         dict_float = dot[3.3]
         dict_bool = dot[True]
-        dict_None = dot[None]
+        dict_none = dot[None]
         nested_dict_float = dot['nested,4.4']
         self.assertEqual(dict_float, 'float')
         self.assertEqual(dict_bool, 'bool')
-        self.assertEqual(dict_None, 'None')
+        self.assertEqual(dict_none, 'None')
         self.assertEqual(nested_dict_float, 'nested_float')

--- a/tests/test_dotty_value_access.py
+++ b/tests/test_dotty_value_access.py
@@ -236,6 +236,7 @@ class TestDottyValueAccess(unittest.TestCase):
         dot = Dotty({
             3.3: 'float',
             True: 'bool',
+            None: 'None',
             'nested': {
                 4.4: 'nested_float'
             }
@@ -243,7 +244,9 @@ class TestDottyValueAccess(unittest.TestCase):
 
         dict_float = dot[3.3]
         dict_bool = dot[True]
+        dict_None = dot[None]
         nested_dict_float = dot['nested,4.4']
         self.assertEqual(dict_float, 'float')
         self.assertEqual(dict_bool, 'bool')
+        self.assertEqual(dict_None, 'None')
         self.assertEqual(nested_dict_float, 'nested_float')


### PR DESCRIPTION
In this review:
* I fixed bug #50. I also implemented mechanism that will support different key types than string. Even when key will be integer, but data will not be list then dotty will gather proper value.
Also, keys may be float or bool type. However, float type requires different separator than dot and bool may be only top level key and may be gathered with dot[True].

* Added unittests that covers these utilities

* Added Limitations section to README
