### PR TITLE
[BUG] Fix bug where list item index is the last in string

### DIFF
--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -104,7 +104,10 @@ class Dotty:
             if it.isdigit():
                 idx = int(it)
                 if idx < len(data):
-                    return search_in(items, data[idx])
+                    if items:
+                        return search_in(items, data[idx])
+                    else:
+                        return data[idx]
                 else:
                     return False
 

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -106,3 +106,17 @@ class TestListInDotty(unittest.TestCase):
         self.assertDictEqual(dot.to_dict(), {'field': [
             {'subfield1': 'Value of subfield1 (item 0)'},
         ]})
+
+    def test_list_as_return_value(self):
+        dot = dotty({
+            'field': [
+                'list_field0',
+                'list_field1'
+            ]
+        })
+
+        self.assertEqual(dot['field.0'], 'list_field0')
+        self.assertEqual(dot['field.1'], 'list_field1')
+        self.assertTrue('field.0' in dot)
+        self.assertTrue('field.1' in dot)
+        self.assertFalse('field.2' in dot)


### PR DESCRIPTION
I fixed the bug #52. It was a problem with list as lat element where no matter whether it was the last key or not, dotty tried to lookup next key. Now everything should work properly. I also added unit test to test gather of data with list as last element and also some tests to contain function (as alita91has tested it in his bug report).