### PR TITLE
Patch Dotty.get to include IndexError

### DIFF
--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -268,7 +268,7 @@ class Dotty:
         """
         try:
             return self.__getitem__(key)
-        except KeyError:
+        except (KeyError, IndexError):
             return default
 
     def pop(self, key, default=None):

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -58,9 +58,9 @@ class TestListInDotty(unittest.TestCase):
         with self.assertRaises(KeyError):
             val = self.dot['field3.subfield1']  # noqa
 
-    def test_assert_return_default_if_index_is_out_of_range(self):
-        val = self.dot['field3.4.subfield1']  # noqa
-        assert val is None
+    def test_assert_index_error_if_index_is_out_of_range(self):
+        with self.assertRaises(IndexError):
+            val = self.dot['field3.4.subfield1']  # noqa
 
     def test_set_subfield_in_list(self):
         dot = dotty()

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -58,9 +58,9 @@ class TestListInDotty(unittest.TestCase):
         with self.assertRaises(KeyError):
             val = self.dot['field3.subfield1']  # noqa
 
-    def test_assert_index_error_if_index_is_out_of_range(self):
-        with self.assertRaises(IndexError):
-            val = self.dot['field3.4.subfield1']  # noqa
+    def test_assert_return_default_if_index_is_out_of_range(self):
+        val = self.dot['field3.4.subfield1']  # noqa
+        assert val is None
 
     def test_set_subfield_in_list(self):
         dot = dotty()

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -62,6 +62,10 @@ class TestListInDotty(unittest.TestCase):
         with self.assertRaises(IndexError):
             val = self.dot['field3.4.subfield1']  # noqa
 
+    def test_assert_get_returns_default_if_index_is_out_of_range(self):
+        val = self.dot.get('field3.4.subfield1')
+        assert val is None
+        
     def test_set_subfield_in_list(self):
         dot = dotty()
 

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -65,7 +65,7 @@ class TestListInDotty(unittest.TestCase):
     def test_assert_get_returns_default_if_index_is_out_of_range(self):
         val = self.dot.get('field3.4.subfield1')
         assert val is None
-        
+
     def test_set_subfield_in_list(self):
         dot = dotty()
 


### PR DESCRIPTION
The behavior where an IndexError is raised if an index in the dotty_dict key doesn't exist is unintuitive, since KeyError is not raised for keys that don't exist. Added IndexError to exception tuple.