### PR TITLE
[Feature] Add support for list slices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Features
 * Access dicts in lists by index ``dot['parents.0.first_name']``
 * key=value caching to speed up lookups and low down memory consumption
 * support for setting value in multidimensional lists
+* support for accessing lists with slices
 
 
 Installation

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -97,6 +97,19 @@ This scenario shows how to access subfield in a list.
    :emphasize-lines: 4
 
 
+Access multiple fields with list slices
+=======================================
+
+This scenario shows how to access multiple subfields in a list of dicts.
+
+.. literalinclude:: ../example/advanced.py
+   :language: python
+   :dedent: 4
+   :start-after: list_slices
+   :end-before: # end of list_slices
+   :emphasize-lines: 4
+
+
 Escape character
 ================
 

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -158,6 +158,9 @@ class Dotty:
                 it = int(it)
             elif it not in data and isinstance(data, dict):
                 it = self._find_data_type(it, data)
+            elif isinstance(data, list) and ':' in it:
+                list_slice = slice(*map(lambda x: None if x == '' else int(x), it.split(':')))
+                return [get_from(items.copy(), x) for x in  data[list_slice]]
             try:
                 data = data[it]
             except TypeError:

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -160,7 +160,10 @@ class Dotty:
                 it = self._find_data_type(it, data)
             elif isinstance(data, list) and ':' in it:
                 list_slice = slice(*map(lambda x: None if x == '' else int(x), it.split(':')))
-                return [get_from(items.copy(), x) for x in  data[list_slice]]
+                if items:
+                    return [get_from(items.copy(), x) for x in  data[list_slice]]
+                else:
+                    return data[list_slice]
             try:
                 data = data[it]
             except TypeError:

--- a/example/advanced.py
+++ b/example/advanced.py
@@ -91,6 +91,27 @@ def list_embedded():
     # end of list_embedded
 
 
+def list_slices():
+    from dotty_dict import dotty
+
+    # dotty supports standard Python slices for lists
+
+    dot = dotty({
+        'annotations': [
+            {'label': 'app', 'value': 'webapi'},
+            {'label': 'role', 'value': 'admin'},
+            {'label': 'service', 'value': 'mail'},
+            {'label': 'database', 'value': 'postgres'}
+        ],
+    })
+
+    assert dot['annotations.:.label'] == ['app', 'role', 'service', 'database']
+    assert dot['annotations.:2.label'] == ['app', 'role']
+    assert dot['annotations.2:.label'] == ['service', 'database']
+    assert dot['annotations.::2.label'] == ['app', 'service']
+    # end of list_slices
+
+
 def escape_character():
     from dotty_dict import dotty
 

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -157,7 +157,8 @@ class TestMultipleSelectList(unittest.TestCase):
                         {
                             "nestedsubfield1": "nestedvalue011",
                             "nestedsubfield2": "nestedvalue012"
-                        }                    ]
+                        }
+                    ]
                 },
                 {
                     "subfield1": [
@@ -168,7 +169,8 @@ class TestMultipleSelectList(unittest.TestCase):
                         {
                             "nestedsubfield1": "nestedvalue111",
                             "nestedsubfield2": "nestedvalue112"
-                        }                    ]
+                        }
+                    ]
                 }
             ]
         })
@@ -197,3 +199,24 @@ class TestMultipleSelectList(unittest.TestCase):
     def test_step_slice(self):
         expected_list = ['value01', 'value21']
         self.assertListEqual(self.dot['field1.::2.subfield1'], expected_list)
+
+    def test_return_whole_list(self):
+        expected_list = [
+                {
+                    "subfield1": "value01",
+                    "subfield2": "value02"
+                },
+                {
+                    "subfield1": "value11",
+                    "subfield2": "value12"
+                },
+                {
+                    "subfield1": "value21",
+                    "subfield2": "value22"
+                },
+                {
+                    "subfield1": "value31",
+                    "subfield2": "value32"
+                }
+            ]
+        self.assertListEqual(self.dot['field1.:'], expected_list)

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -202,21 +202,21 @@ class TestMultipleSelectList(unittest.TestCase):
 
     def test_return_whole_list(self):
         expected_list = [
-                {
-                    "subfield1": "value01",
-                    "subfield2": "value02"
-                },
-                {
-                    "subfield1": "value11",
-                    "subfield2": "value12"
-                },
-                {
-                    "subfield1": "value21",
-                    "subfield2": "value22"
-                },
-                {
-                    "subfield1": "value31",
-                    "subfield2": "value32"
-                }
-            ]
+            {
+                "subfield1": "value01",
+                "subfield2": "value02"
+            },
+            {
+                "subfield1": "value11",
+                "subfield2": "value12"
+            },
+            {
+                "subfield1": "value21",
+                "subfield2": "value22"
+            },
+            {
+                "subfield1": "value31",
+                "subfield2": "value32"
+            }
+        ]
         self.assertListEqual(self.dot['field1.:'], expected_list)

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -124,3 +124,76 @@ class TestListInDotty(unittest.TestCase):
         self.assertTrue('field.0' in dot)
         self.assertTrue('field.1' in dot)
         self.assertFalse('field.2' in dot)
+
+
+class TestMultipleSelectList(unittest.TestCase):
+    def setUp(self):
+        self.dot = dotty({
+            'field1': [
+                {
+                    "subfield1": "value01",
+                    "subfield2": "value02"
+                },
+                {
+                    "subfield1": "value11",
+                    "subfield2": "value12"
+                },
+                {
+                    "subfield1": "value21",
+                    "subfield2": "value22"
+                },
+                {
+                    "subfield1": "value31",
+                    "subfield2": "value32"
+                }
+            ],
+            "field2": [
+                {
+                    "subfield1": [
+                        {
+                            "nestedsubfield1": "nestedvalue001",
+                            "nestedsubfield2": "nestedvalue002"
+                        },
+                        {
+                            "nestedsubfield1": "nestedvalue011",
+                            "nestedsubfield2": "nestedvalue012"
+                        }                    ]
+                },
+                {
+                    "subfield1": [
+                        {
+                            "nestedsubfield1": "nestedvalue101",
+                            "nestedsubfield2": "nestedvalue102"
+                        },
+                        {
+                            "nestedsubfield1": "nestedvalue111",
+                            "nestedsubfield2": "nestedvalue112"
+                        }                    ]
+                }
+            ]
+        })
+
+    def test_whole_shallow_multiple_list(self):
+        expected_list = ['value01', 'value11', 'value21', 'value31']
+        self.assertListEqual(self.dot['field1.:.subfield1'], expected_list)
+
+    def test_whole_nested_multiple_list(self):
+        expected_list = [['nestedvalue001', 'nestedvalue011'],
+                         ['nestedvalue101', 'nestedvalue111']]
+        self.assertListEqual(self.dot['field2.:.subfield1.:.nestedsubfield1'], expected_list)
+
+    def test_left_side_slice(self):
+        expected_list = ['value21', 'value31']
+        self.assertListEqual(self.dot['field1.2:.subfield1'], expected_list)
+
+    def test_right_side_slice(self):
+        expected_list = ['value01', 'value11']
+        self.assertListEqual(self.dot['field1.:2.subfield1'], expected_list)
+
+    def test_both_side_slice(self):
+        expected_list = ['value11', 'value21']
+        self.assertListEqual(self.dot['field1.1:3.subfield1'], expected_list)
+
+    def test_step_slice(self):
+        expected_list = ['value01', 'value21']
+        self.assertListEqual(self.dot['field1.::2.subfield1'], expected_list)


### PR DESCRIPTION
Related to Issue #60 requested by @coolacid .

In this PR:
I've added code that allows to pass standard Python list slices (:, 2:, :3, ::6 etc.) when accessing field which is list.

Thanks to that user may specify to get for example only first 3 items in list.
Additionally, slices does not have to be the last item in dotty items. It's possible to select from list 3 first dictionaries (which have the same keys) and return list of values from 3 dictionaries - examples are attached in advanced examples and unit tests cases.

