### PR TITLE
[Feature/Back to the future] Add no_list flag

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -110,6 +110,19 @@ This scenario shows how to access multiple subfields in a list of dicts.
    :emphasize-lines: 4
 
 
+Access numeric fields as dict keys
+==================================
+
+This scenario shows how to access numeric keys which should not be treated as list indices
+
+.. literalinclude:: ../example/advanced.py
+   :language: python
+   :dedent: 4
+   :start-after: no_list
+   :end-before: # end of no_list
+   :emphasize-lines: 4
+
+
 Escape character
 ================
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -113,13 +113,13 @@ This scenario shows how to access multiple subfields in a list of dicts.
 Access numeric fields as dict keys
 ==================================
 
-This scenario shows how to access numeric keys which should not be treated as list indices
+This scenario shows how to access numeric keys which should not be treated as list indices.
 
 .. literalinclude:: ../example/advanced.py
    :language: python
    :dedent: 4
-   :start-after: no_list
-   :end-before: # end of no_list
+   :start-after: no_list_flag
+   :end-before: # end of no_list_flag
    :emphasize-lines: 4
 
 

--- a/dotty_dict/__init__.py
+++ b/dotty_dict/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from dotty_dict.dotty_dict import Dotty, dotty, dotty_l
+from dotty_dict.dotty_dict import Dotty, dotty
 
 __author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2017, Paweł Zadrożny'
 __email__ = 'pawel.zny@gmail.com'
 __version__ = '1.2.1'
-__all__ = ['Dotty', 'dotty', 'dotty_l']
+__all__ = ['Dotty', 'dotty']

--- a/example/advanced.py
+++ b/example/advanced.py
@@ -113,7 +113,7 @@ def list_slices():
     # end of list_slices
 
 
-def no_list():
+def no_list_flag():
     from dotty_dict import dotty
 
     # For special use cases dotty supports dictionary key only access
@@ -131,7 +131,7 @@ def no_list():
     assert dot['special.1'] == 'one'
     assert dot['special.:'] == 'colon'
     assert dot['special.2:'] == 'two colons'
-    # end of no_list
+    # end of no_list_flag
 
 
 def escape_character():

--- a/example/advanced.py
+++ b/example/advanced.py
@@ -63,7 +63,8 @@ def list_embedded():
     # dotty supports embedded lists
     # WARNING!
     # Dotty used to support lists only with dotty_l.
-    # This feature is depreciated - now lists have native support.
+    # This feature is depreciated and was removed - now lists have native support.
+    # If you need old functionality pass additional flag 'no_list' to dotty
 
     dot = dotty({
         'annotations': [
@@ -71,9 +72,9 @@ def list_embedded():
             {'label': 'role', 'value': 'admin'},
         ],
         'spec': {
-             'containers': [
-                 ['gpu', 'tensorflow', 'ML'],
-                 ['cpu', 'webserver', 'sql'],
+            'containers': [
+                ['gpu', 'tensorflow', 'ML'],
+                ['cpu', 'webserver', 'sql'],
             ]
         }
     })
@@ -110,6 +111,27 @@ def list_slices():
     assert dot['annotations.2:.label'] == ['service', 'database']
     assert dot['annotations.::2.label'] == ['app', 'service']
     # end of list_slices
+
+
+def no_list():
+    from dotty_dict import dotty
+
+    # For special use cases dotty supports dictionary key only access
+    # With additional flag no_list passed to dotty
+    # all digits and slices will be treated as string keys
+
+    dot = dotty({
+        'special': {
+            '1': 'one',
+            ':': 'colon',
+            '2:': 'two colons'
+        }
+    })
+
+    assert dot['special.1'] == 'one'
+    assert dot['special.:'] == 'colon'
+    assert dot['special.2:'] == 'two colons'
+    # end of no_list
 
 
 def escape_character():

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from dotty_dict import dotty_l as dotty
+from dotty_dict import dotty
 
 
 class TestListInDotty(unittest.TestCase):
@@ -220,3 +220,31 @@ class TestMultipleSelectList(unittest.TestCase):
             }
         ]
         self.assertListEqual(self.dot['field1.:'], expected_list)
+
+
+class TestNoList(unittest.TestCase):
+    def setUp(self):
+        self.dot = dotty({
+            'field1': {
+                '1': 'value1',
+                '2': {
+                    'subfield1': 'value2',
+                    'subfield2': 'value3'
+                },
+                ':': 'value4',
+                '2:': 'value5',
+                'key': 'value6'
+            },
+        }, no_list=True)
+
+    def test_simple_index(self):
+        self.assertEqual(self.dot['field1.1'], 'value1')
+
+    def test_whole_slice_index(self):
+        self.assertEqual(self.dot['field1.:'], 'value4')
+
+    def test_limit_slice_index(self):
+        self.assertEqual(self.dot['field1.2:'], 'value5')
+
+    def test_normal_key(self):
+        self.assertEqual(self.dot['field1.key'], 'value6')


### PR DESCRIPTION
Based on comments from @pierwszywolny in Issue #58 I've added optional flag no_list defaulted to False
which allows to omit features with lists that we've developed and use dotty the old style - where all numeric or slices keys are treated as string keys in dictionary.

I think that this change modifies only two points in the main code and does not add a lot of complexity, so in my opinion we may provide that additional support.

Also, I've removed deprecation warnings and dotty_l function as final goodbye for this legacy form. :)