### PR TITLE
Remove Polish letters from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.develop import develop
 from setuptools.command.install import install
 from setuptools.command.test import test
 
-__author__ = 'Paweł Zadrożny'
+__author__ = 'Pawel Zadrozny'
 __copyright__ = 'Copyright (c) 2018, Pawelzny'
 
 with open('README.rst', 'r') as readme_file:
@@ -49,7 +49,7 @@ setup(
     description="Dictionary wrapper for quick access to deeply nested keys.",
     long_description=readme,
     license="MIT license",
-    author="Paweł Zadrożny @pawelzny",
+    author="Pawel Zadrozny @pawelzny",
     author_email='pawel.zny@gmail.com',
     url='https://github.com/pawelzny/dotty_dict',
     packages=find_packages(exclude=('tests', 'docs', 'bin', 'example')),


### PR DESCRIPTION
This PR is caused by this Issue: #69 

Polish letters may indeed cause problems in some environments and probably it'll be safer to just replace them with standard letters.
Hope so @pawelzny that it'll not be problem for you that some ł and ż will be missing ;)