### PR TITLE
Use setuptools_scm for setup instead of install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     package_dir={'dotty_dict': 'dotty_dict'},
     include_package_data=True,
     use_scm_version=True,
-    install_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm'],
     zip_safe=False,
     keywords='dot notation dict wrapper helper utils lib',
     classifiers=[


### PR DESCRIPTION
Based on [setuptools-scm](https://pypi.org/project/setuptools-scm/) usage documentation, this package should be declared at `setup_requires` instead of `install_requires`.

Spotted this small mistake after trying to submit a [package recipe](https://github.com/conda-forge/staged-recipes/pull/14183) at conda-forge.

Since this package is only needed for setup instead of running the library, the change shouldn't affect any upcoming release.

Cheers!