### PR TITLE
flaky test fix on caching

### DIFF
--- a/tests/test_dotty_cache.py
+++ b/tests/test_dotty_cache.py
@@ -7,8 +7,9 @@ from dotty_dict import dotty
 class TestDottyCache(unittest.TestCase):
 
     def test_getitem_cache(self):
-        dot = dotty()
+        dot = dotty(None, None)
         dot._data = MagicMock()
         for _ in range(10):
             dot.get('x.y.z')
         self.assertEqual(dot.__getitem__.cache_info().hits, 9)
+        dot.__getitem__.cache_clear()

--- a/tests/test_dotty_cache.py
+++ b/tests/test_dotty_cache.py
@@ -7,7 +7,7 @@ from dotty_dict import dotty
 class TestDottyCache(unittest.TestCase):
 
     def test_getitem_cache(self):
-        dot = dotty(None, None)
+        dot = dotty()
         dot.__getitem__.cache_clear()
         dot._data = MagicMock()
         for _ in range(10):

--- a/tests/test_dotty_cache.py
+++ b/tests/test_dotty_cache.py
@@ -8,6 +8,7 @@ class TestDottyCache(unittest.TestCase):
 
     def test_getitem_cache(self):
         dot = dotty(None, None)
+        dot.__getitem__.cache_clear()
         dot._data = MagicMock()
         for _ in range(10):
             dot.get('x.y.z')


### PR DESCRIPTION
In order to prevent polluting the cache with the test and make sure it will not be affected by the polluted cache, I will clear the cache every time.
Problem location:
test_dotty_cache.py
Flaky report generated by pytest --flake-finder plugin:
```
______________________ TestDottyCache.test_getitem_cache ______________________

self = <tests.test_dotty_cache.TestDottyCache testMethod=test_getitem_cache>

    def test_getitem_cache(self):
        dot = dotty(None, None)
        dot._data = MagicMock()
        for _ in range(10):
            dot.get('x.y.z')
>       self.assertEqual(dot.__getitem__.cache_info().hits, 9)
E       AssertionError: 423 != 9

test_dotty_cache.py:14: AssertionError
______________________ TestDottyCache.test_getitem_cache ______________________

self = <tests.test_dotty_cache.TestDottyCache testMethod=test_getitem_cache>

    def test_getitem_cache(self):
        dot = dotty(None, None)
        dot._data = MagicMock()
        for _ in range(10):
            dot.get('x.y.z')
>       self.assertEqual(dot.__getitem__.cache_info().hits, 9)
E       AssertionError: 432 != 9

test_dotty_cache.py:14: AssertionError
______________________ TestDottyCache.test_getitem_cache ______________________

self = <tests.test_dotty_cache.TestDottyCache testMethod=test_getitem_cache>

    def test_getitem_cache(self):
        dot = dotty(None, None)
        dot._data = MagicMock()
        for _ in range(10):
            dot.get('x.y.z')
>       self.assertEqual(dot.__getitem__.cache_info().hits, 9)
E       AssertionError: 441 != 9

test_dotty_cache.py:14: AssertionError
______________________ TestDottyCache.test_getitem_cache ______________________

self = <tests.test_dotty_cache.TestDottyCache testMethod=test_getitem_cache>

    def test_getitem_cache(self):
        dot = dotty(None, None)
        dot._data = MagicMock()
        for _ in range(10):
            dot.get('x.y.z')
>       self.assertEqual(dot.__getitem__.cache_info().hits, 9)
E       AssertionError: 450 != 9

test_dotty_cache.py:14: AssertionError

``` 
Part of error message.
Result after fixed:
passed on normal pytest run and passed 50 reruns of flake finder

Way to check this in original file:
go to tests/
install flake-finder according to 
https://github.com/dropbox/pytest-flakefinder
run
```
pytest test_dotty_cache.py --flake-finder
```