### PR TITLE
Better fix for encoding issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Dotty-Dict
 **********
 
 :Info: Dictionary wrapper for quick access to deeply nested keys.
-:Author: Pawel Zadrozny @pawelzny <pawel.zny@gmail.com>
+:Author: Paweł Zadrożny @pawelzny <pawel.zny@gmail.com>
 
 .. image:: https://circleci.com/gh/pawelzny/dotty_dict/tree/master.svg?style=shield&circle-token=77f51e87481f339d69ca502fdbb0c2b1a76c0369
    :target: https://circleci.com/gh/pawelzny/dotty_dict/tree/master

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.develop import develop
 from setuptools.command.install import install
 from setuptools.command.test import test
 
-__author__ = 'Pawel Zadrozny'
+__author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2018, Pawelzny'
 
 with open('README.rst', 'r') as readme_file:
@@ -49,7 +49,7 @@ setup(
     description="Dictionary wrapper for quick access to deeply nested keys.",
     long_description=readme,
     license="MIT license",
-    author="Pawel Zadrozny @pawelzny",
+    author="Paweł Zadrożny @pawelzny",
     author_email='pawel.zny@gmail.com',
     url='https://github.com/pawelzny/dotty_dict',
     packages=find_packages(exclude=('tests', 'docs', 'bin', 'example')),

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ from setuptools.command.test import test
 __author__ = 'Paweł Zadrożny'
 __copyright__ = 'Copyright (c) 2018, Pawelzny'
 
-with open('README.rst', 'r') as readme_file:
+with open('README.rst', 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 
 def get_version(*file_paths):
     """Retrieves the version from project/__init__.py"""
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
-    version_file = open(filename).read()
+    version_file = open(filename, encoding='utf-8').read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:


### PR DESCRIPTION
As mentioned in this comment: https://github.com/pawelzny/dotty_dict/issues/69#issuecomment-978953755 there is no need to remove the special characters; the files simply need to be read as UTF-8 instead of letting the host environment decide. I confirmed this works in a completely fresh MSYS2 install on a Windows 10 VM set to Japanese everything.

Resolves #69
Closes #86