### PR TITLE
Fix for the error Object of type datetime is not JSON serializable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Dotty-Dict
 **********
 
-:Info: Dictionary wrapper for quick access to deeply nested keys.
-:Author: Pawel Zadrozny @pawelzny <pawel.zny@gmail.com>
+:Info: This is a fork of dictionary wrapper for quick access to deeply nested keys.
+:Author: Pawel Zadrozny @pawelzny <pawel.zny@gmail.com>, Risto Kowaczewski
 
 .. image:: https://circleci.com/gh/pawelzny/dotty_dict/tree/master.svg?style=shield&circle-token=77f51e87481f339d69ca502fdbb0c2b1a76c0369
    :target: https://circleci.com/gh/pawelzny/dotty_dict/tree/master

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -320,7 +320,8 @@ class Dotty:
 
         :return str: Wrapped dictionary as json string
         """
-        return json.dumps(self._data, cls=DottyEncoder)
+
+        return json.dumps(self._data, cls=DottyEncoder, default=str)
 
     def _split(self, key):
         """Split dot notated chain of keys.
@@ -349,6 +350,7 @@ class Dotty:
 class DottyEncoder(json.JSONEncoder):
     """Helper class for encoding of nested Dotty dicts into standard dict
     """
+
     def default(self, obj):
         """Return dict data of Dotty when possible or encode with standard format
 

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -320,7 +320,6 @@ class Dotty:
 
         :return str: Wrapped dictionary as json string
         """
-
         return json.dumps(self._data, cls=DottyEncoder, default=str)
 
     def _split(self, key):

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -320,7 +320,7 @@ class Dotty:
 
         :return str: Wrapped dictionary as json string
         """
-        return json.dumps(self._data, cls=DottyEncoder, default=str)
+        return json.dumps(self._data, cls=DottyEncoder)
 
     def _split(self, key):
         """Split dot notated chain of keys.
@@ -357,7 +357,10 @@ class DottyEncoder(json.JSONEncoder):
 
         :return: Serializable data
         """
-        if hasattr(obj, '_data'):
-            return obj._data
-        else:
-            return json.JSONEncoder.default(self, obj)
+        try:
+            if hasattr(obj, '_data'):
+                return obj._data
+            else:
+                return json.JSONEncoder.default(self, obj)
+        except TypeError:
+            return str(obj)

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -96,6 +96,9 @@ class Dotty:
                 else:
                     return False
 
+            if not data:
+                return False
+
             if items and it in data:
                 return search_in(items, data[it])
             return it in data

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -231,7 +231,7 @@ class Dotty:
 
     def __delitem__(self, key):
         def del_key(items, data):
-            """Recursively remove deep key from dict.
+            """Recursively remove deep key from dict and remove empty parent dictionaries.
 
             :param list items: List of dictionary keys
             :param data: Portion of dictionary to operate on
@@ -242,8 +242,14 @@ class Dotty:
                 it = int(it)
             if items:
                 del_key(items, data[it])
+                # Remove the parent dictionary if it's empty
+                if isinstance(data[it], dict) and not data[it]:
+                    del data[it]
             else:
                 del data[it]
+                # Remove the parent dictionary if it's empty
+                if isinstance(data, dict) and not data:
+                    data.clear()
 
         del_key(self._split(key), self._data)
 

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -200,6 +200,21 @@ class Dotty:
 
         set_to(self._split(key), self._data)
 
+    def __getstate__(self):
+        return {
+            '_data': self._data,
+            'separator': self.separator,
+            'esc_char': self.esc_char,
+            'no_list': self.no_list
+        }
+
+    def __setstate__(self, state):
+        self._data = state['_data']
+        self.separator = state['separator']
+        self.esc_char = state['esc_char']
+        self.no_list = state['no_list']
+
+
     @staticmethod
     def set_list_index(data, index, value):
         """Set value in list at specified index.

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+import pickle
+from dotty_dict import dotty
+
+
+class TestListInDotty(unittest.TestCase):
+
+    def test_1(self):
+        data = {
+            "A": {
+                "B": {
+                    "C": {
+                        "D": 1,
+                        "E": 2
+                    }
+                }
+            }
+        }
+        dot = dotty(data)
+
+        del dot['A.B.C.D']
+
+        self.assertEqual(dot.to_dict(), {'A': {'B': {'C': {'E': 2}}}})
+
+
+
+    def test_2(self):
+        data = {
+            "A": {
+                "B": {
+                    "C": {
+                        "D": 1
+                    }
+                }
+            }
+        }
+        dot = dotty(data)
+
+        del dot['A.B.C.D']
+
+        self.assertEqual(dot.to_dict(), {})

--- a/tests/test_non_json_serilizables.py
+++ b/tests/test_non_json_serilizables.py
@@ -18,4 +18,3 @@ class TestListInDotty(unittest.TestCase):
         })
 
         self.assertEqual(dot.to_dict(), {'date': 'test'})
-

--- a/tests/test_non_json_serilizables.py
+++ b/tests/test_non_json_serilizables.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+
+from dotty_dict import dotty
+
+
+class NoneSerializable:
+    def __str__(self):
+        return "test"
+
+
+class TestListInDotty(unittest.TestCase):
+
+    def test_should_to_dict(self):
+        dot = dotty({
+            "date": NoneSerializable()
+        })
+
+        self.assertEqual(dot.to_dict(), {'date': 'test'})
+

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+import pickle
+from dotty_dict import dotty
+
+
+class TestListInDotty(unittest.TestCase):
+
+    def test_should_serialize_and_deserialize(self):
+        data = {
+            "a": 1
+        }
+        dot = dotty(data)
+
+        serialized = pickle.dumps(dot)
+        deserialized = pickle.loads(serialized)
+
+        self.assertEqual(deserialized, data)


### PR DESCRIPTION
Fixes the error when you try to to_dict() object that has datetime object or any object that can not be serialized to json. 