### PR TITLE
Fix list indexing negative values

### DIFF
--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -86,7 +86,7 @@ class Dotty:
             :return bool: Predicate of key existence
             """
             it = items.pop(0)
-            if it.isdigit():
+            if it.lstrip("-").isdigit():
                 idx = int(it)
                 if idx < len(data):
                     if items:
@@ -139,7 +139,7 @@ class Dotty:
             :raises KeyError: If key does not exist
             """
             it = items.pop(0)
-            if isinstance(data, list) and it.isdigit() and not self.no_list:
+            if isinstance(data, list) and it.lstrip("-").isdigit() and not self.no_list:
                 it = int(it)
             elif it not in data and isinstance(data, dict):
                 it = self._find_data_type(it, data)
@@ -171,12 +171,12 @@ class Dotty:
             it = items.pop(0)
             if items:
 
-                if items[0].isdigit():
+                if items[0].lstrip("-").isdigit():
                     next_item = []
                 else:
                     next_item = {}
 
-                if it.isdigit():
+                if it.lstrip("-").isdigit():
                     it = int(it)
                     try:
                         if not data[it]:
@@ -190,7 +190,7 @@ class Dotty:
                     set_to(items, data[it])
 
             else:
-                if it.isdigit():
+                if it.lstrip("-").isdigit():
                     self.set_list_index(data, it, value)
                 else:
                     data[it] = value
@@ -220,7 +220,7 @@ class Dotty:
             :raises KeyError: If key does not exist
             """
             it = items.pop(0)
-            if it.isdigit():
+            if it.lstrip("-").isdigit():
                 it = int(it)
             if items:
                 del_key(items, data[it])

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -8,8 +8,7 @@ except ImportError:
 from functools import lru_cache
 import json
 
-__author__ = 'Pawel Zadrozny'
-__copyright__ = 'Copyright (c) 2017, Pawel Zadrozny'
+__copyright__ = "Copyright (c) 2017, Pawel Zadrozny"
 
 
 def dotty(dictionary=None, no_list=False):
@@ -23,7 +22,7 @@ def dotty(dictionary=None, no_list=False):
     """
     if dictionary is None:
         dictionary = {}
-    return Dotty(dictionary, separator='.', esc_char='\\', no_list=no_list)
+    return Dotty(dictionary, separator=".", esc_char="\\", no_list=no_list)
 
 
 class Dotty:
@@ -46,9 +45,9 @@ class Dotty:
     :param bool no_list: If set to True then numeric keys will NOT be converted to list indices
     """
 
-    def __init__(self, dictionary, separator='.', esc_char='\\', no_list=False):
+    def __init__(self, dictionary, separator=".", esc_char="\\", no_list=False):
         if not isinstance(dictionary, (Mapping, dict)):
-            raise AttributeError('Dictionary must be type of dict')
+            raise AttributeError("Dictionary must be type of dict")
         else:
             self._data = dictionary
         self.separator = separator
@@ -56,8 +55,9 @@ class Dotty:
         self.no_list = no_list
 
     def __repr__(self):
-        return 'Dotty(dictionary={}, separator={!r}, esc_char={!r})'.format(
-            self._data, self.separator, self.esc_char)
+        return "Dotty(dictionary={}, separator={!r}, esc_char={!r})".format(
+            self._data, self.separator, self.esc_char
+        )
 
     def __str__(self):
         return str(self._data)
@@ -86,7 +86,7 @@ class Dotty:
             :return bool: Predicate of key existence
             """
             it = items.pop(0)
-            if it.isdigit():
+            if it.lstrip("-").isdigit():
                 idx = int(it)
                 if idx < len(data):
                     if items:
@@ -139,13 +139,15 @@ class Dotty:
             :raises KeyError: If key does not exist
             """
             it = items.pop(0)
-            if isinstance(data, list) and it.isdigit() and not self.no_list:
+            if isinstance(data, list) and it.lstrip("-").isdigit() and not self.no_list:
                 it = int(it)
             elif it not in data and isinstance(data, dict):
                 it = self._find_data_type(it, data)
-            elif isinstance(data, list) and ':' in it and not self.no_list:
+            elif isinstance(data, list) and ":" in it and not self.no_list:
                 # TODO: fix C417 Unnecessary use of map - use a generator expression instead.
-                list_slice = slice(*map(lambda x: None if x == '' else int(x), it.split(':')))  # noqa: C417
+                list_slice = slice(
+                    *map(lambda x: None if x == "" else int(x), it.split(":"))
+                )  # noqa: C417
                 if items:
                     return [get_from(items.copy(), x) for x in data[list_slice]]
                 else:
@@ -170,13 +172,12 @@ class Dotty:
             """
             it = items.pop(0)
             if items:
-
-                if items[0].isdigit():
+                if items[0].lstrip("-").isdigit():
                     next_item = []
                 else:
                     next_item = {}
 
-                if it.isdigit():
+                if it.lstrip("-").isdigit():
                     it = int(it)
                     try:
                         if not data[it]:
@@ -190,7 +191,7 @@ class Dotty:
                     set_to(items, data[it])
 
             else:
-                if it.isdigit():
+                if it.lstrip("-").isdigit():
                     self.set_list_index(data, it, value)
                 else:
                     data[it] = value
@@ -220,7 +221,7 @@ class Dotty:
             :raises KeyError: If key does not exist
             """
             it = items.pop(0)
-            if it.isdigit():
+            if it.lstrip("-").isdigit():
                 it = int(it)
             if items:
                 del_key(items, data[it])
@@ -332,11 +333,11 @@ class Dotty:
         """
         if not isinstance(key, str):
             return [key]
-        esc_stamp = (self.esc_char + self.separator, '<#esc#>')
-        skp_stamp = ('\\' + self.esc_char + self.separator, '<#skp#>' + self.separator)
+        esc_stamp = (self.esc_char + self.separator, "<#esc#>")
+        skp_stamp = ("\\" + self.esc_char + self.separator, "<#skp#>" + self.separator)
 
-        stamp_esc = ('<#esc#>', self.separator)
-        stamp_skp = ('<#skp#>', self.esc_char)
+        stamp_esc = ("<#esc#>", self.separator)
+        stamp_skp = ("<#skp#>", self.esc_char)
 
         key = key.replace(*skp_stamp).replace(*esc_stamp)
         keys = key.split(self.separator)
@@ -347,8 +348,8 @@ class Dotty:
 
 
 class DottyEncoder(json.JSONEncoder):
-    """Helper class for encoding of nested Dotty dicts into standard dict
-    """
+    """Helper class for encoding of nested Dotty dicts into standard dict"""
+
     def default(self, obj):
         """Return dict data of Dotty when possible or encode with standard format
 
@@ -356,7 +357,7 @@ class DottyEncoder(json.JSONEncoder):
 
         :return: Serializable data
         """
-        if hasattr(obj, '_data'):
+        if hasattr(obj, "_data"):
             return obj._data
         else:
             return json.JSONEncoder.default(self, obj)

--- a/dotty_dict/dotty_dict.py
+++ b/dotty_dict/dotty_dict.py
@@ -8,7 +8,8 @@ except ImportError:
 from functools import lru_cache
 import json
 
-__copyright__ = "Copyright (c) 2017, Pawel Zadrozny"
+__author__ = 'Pawel Zadrozny'
+__copyright__ = 'Copyright (c) 2017, Pawel Zadrozny'
 
 
 def dotty(dictionary=None, no_list=False):
@@ -22,7 +23,7 @@ def dotty(dictionary=None, no_list=False):
     """
     if dictionary is None:
         dictionary = {}
-    return Dotty(dictionary, separator=".", esc_char="\\", no_list=no_list)
+    return Dotty(dictionary, separator='.', esc_char='\\', no_list=no_list)
 
 
 class Dotty:
@@ -45,9 +46,9 @@ class Dotty:
     :param bool no_list: If set to True then numeric keys will NOT be converted to list indices
     """
 
-    def __init__(self, dictionary, separator=".", esc_char="\\", no_list=False):
+    def __init__(self, dictionary, separator='.', esc_char='\\', no_list=False):
         if not isinstance(dictionary, (Mapping, dict)):
-            raise AttributeError("Dictionary must be type of dict")
+            raise AttributeError('Dictionary must be type of dict')
         else:
             self._data = dictionary
         self.separator = separator
@@ -55,9 +56,8 @@ class Dotty:
         self.no_list = no_list
 
     def __repr__(self):
-        return "Dotty(dictionary={}, separator={!r}, esc_char={!r})".format(
-            self._data, self.separator, self.esc_char
-        )
+        return 'Dotty(dictionary={}, separator={!r}, esc_char={!r})'.format(
+            self._data, self.separator, self.esc_char)
 
     def __str__(self):
         return str(self._data)
@@ -86,7 +86,7 @@ class Dotty:
             :return bool: Predicate of key existence
             """
             it = items.pop(0)
-            if it.lstrip("-").isdigit():
+            if it.isdigit():
                 idx = int(it)
                 if idx < len(data):
                     if items:
@@ -139,15 +139,13 @@ class Dotty:
             :raises KeyError: If key does not exist
             """
             it = items.pop(0)
-            if isinstance(data, list) and it.lstrip("-").isdigit() and not self.no_list:
+            if isinstance(data, list) and it.isdigit() and not self.no_list:
                 it = int(it)
             elif it not in data and isinstance(data, dict):
                 it = self._find_data_type(it, data)
-            elif isinstance(data, list) and ":" in it and not self.no_list:
+            elif isinstance(data, list) and ':' in it and not self.no_list:
                 # TODO: fix C417 Unnecessary use of map - use a generator expression instead.
-                list_slice = slice(
-                    *map(lambda x: None if x == "" else int(x), it.split(":"))
-                )  # noqa: C417
+                list_slice = slice(*map(lambda x: None if x == '' else int(x), it.split(':')))  # noqa: C417
                 if items:
                     return [get_from(items.copy(), x) for x in data[list_slice]]
                 else:
@@ -172,12 +170,13 @@ class Dotty:
             """
             it = items.pop(0)
             if items:
-                if items[0].lstrip("-").isdigit():
+
+                if items[0].isdigit():
                     next_item = []
                 else:
                     next_item = {}
 
-                if it.lstrip("-").isdigit():
+                if it.isdigit():
                     it = int(it)
                     try:
                         if not data[it]:
@@ -191,7 +190,7 @@ class Dotty:
                     set_to(items, data[it])
 
             else:
-                if it.lstrip("-").isdigit():
+                if it.isdigit():
                     self.set_list_index(data, it, value)
                 else:
                     data[it] = value
@@ -221,7 +220,7 @@ class Dotty:
             :raises KeyError: If key does not exist
             """
             it = items.pop(0)
-            if it.lstrip("-").isdigit():
+            if it.isdigit():
                 it = int(it)
             if items:
                 del_key(items, data[it])
@@ -333,11 +332,11 @@ class Dotty:
         """
         if not isinstance(key, str):
             return [key]
-        esc_stamp = (self.esc_char + self.separator, "<#esc#>")
-        skp_stamp = ("\\" + self.esc_char + self.separator, "<#skp#>" + self.separator)
+        esc_stamp = (self.esc_char + self.separator, '<#esc#>')
+        skp_stamp = ('\\' + self.esc_char + self.separator, '<#skp#>' + self.separator)
 
-        stamp_esc = ("<#esc#>", self.separator)
-        stamp_skp = ("<#skp#>", self.esc_char)
+        stamp_esc = ('<#esc#>', self.separator)
+        stamp_skp = ('<#skp#>', self.esc_char)
 
         key = key.replace(*skp_stamp).replace(*esc_stamp)
         keys = key.split(self.separator)
@@ -348,8 +347,8 @@ class Dotty:
 
 
 class DottyEncoder(json.JSONEncoder):
-    """Helper class for encoding of nested Dotty dicts into standard dict"""
-
+    """Helper class for encoding of nested Dotty dicts into standard dict
+    """
     def default(self, obj):
         """Return dict data of Dotty when possible or encode with standard format
 
@@ -357,7 +356,7 @@ class DottyEncoder(json.JSONEncoder):
 
         :return: Serializable data
         """
-        if hasattr(obj, "_data"):
+        if hasattr(obj, '_data'):
             return obj._data
         else:
             return json.JSONEncoder.default(self, obj)

--- a/tests/test_list_in_dotty.py
+++ b/tests/test_list_in_dotty.py
@@ -31,10 +31,12 @@ class TestListInDotty(unittest.TestCase):
 
     def test_root_level_list_element(self):
         self.assertEqual(self.dot['field6.0'], 'a')
+        self.assertEqual(self.dot['field6.-1'], 'b')
 
     def test_access_subfield1_of_field3(self):
         self.assertEqual(self.dot['field3.0.subfield1'], 'Value of subfield1 (item 0)')
         self.assertEqual(self.dot['field3.1.subfield1'], 'Value of subfield1 (item 1)')
+        self.assertEqual(self.dot['field3.-1.subfield1'], 'Value of subfield1 (item 1)')
 
     def test_access_sub_sub_field(self):
         self.assertEqual(self.dot['field5.0.subfield1.0.subsubfield'], 'Value of sub subfield (item 0)')
@@ -47,6 +49,7 @@ class TestListInDotty(unittest.TestCase):
             ]
         })
         self.assertEqual(dot['field.1.0.subfield'], 'Value of subfield (item 0,1)')
+        self.assertEqual(dot['field.-1.0.subfield'], 'Value of subfield (item 0,1)')
 
     def test_dotty_contains_subfield_of_field(self):
         self.assertIn('field3.0.subfield2', self.dot)
@@ -72,6 +75,7 @@ class TestListInDotty(unittest.TestCase):
         dot['field.0.subfield'] = 'Value of subfield (item 0)'
         dot['field.1.subfield'] = 'Value of subfield (item 1)'
         dot['field.1.subfield2'] = 'Value of subfield2 (item 1)'
+        dot['field.-1.subfield2'] = 'Value of subfield2 (item 1)'
 
         self.assertDictEqual(dot.to_dict(), {
             'field': [
@@ -123,6 +127,7 @@ class TestListInDotty(unittest.TestCase):
         self.assertEqual(dot['field.1'], 'list_field1')
         self.assertTrue('field.0' in dot)
         self.assertTrue('field.1' in dot)
+        self.assertTrue('field.-1' in dot)
         self.assertFalse('field.2' in dot)
 
     def test_root_level_field_is_none(self):


### PR DESCRIPTION
minor change to allow for negative indexing (e.g. last element of list "-1"). Tests passing locally. 

For example:

```
from dotty_dict import Dotty

i_dict = Dotty(
    {"some": {"nested": {"list": {"here": {"now": [0, 1, 2, 3]}}}}}
)

key = "some.nested.list.here.now.-1"
value = i_dict[key]
print(f"dict value: {value}")
print(f"key in i_dict is {key in i_dict}")
print(f"value type: {type(value)}")

```

should return

```
dict value: 3
key in i_dict is True
value type: <class 'int'>
```
